### PR TITLE
Fix an upgrade ISNI API  URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ Add the service by entering the URL 'http://0.0.0.0:5000/reconcile'.
 Michael Stephens wrote a [demo reconcilliation service](https://github.com/mikejs/reconcile-demo) that this code is based on.
 
 Tested on python 2.7.10 and 3.4.3
+
+URL Example call
+
+http://127.0.0.1:5000/reconcile?query=Jo%C3%ABl%20Dicker&type=/isni/name

--- a/reconcile.py
+++ b/reconcile.py
@@ -2,7 +2,7 @@
 An OpenRefine reconciliation service for the ISNI API.
 
 See API documentation:
-http://isni.oclc.nl/sru/DB=1.2/
+https://isni.oclc.org/sru/DB=1.2/
 
 This code is adapted from Michael Stephens:
 https://github.com/mikejs/reconcile-demo
@@ -23,7 +23,7 @@ import requests
 app = Flask(__name__)
 
 #some config
-api_base_url = 'http://isni.oclc.nl/sru/?operation=searchRetrieve&recordSchema=isni-b&query='
+api_base_url = 'https://isni.oclc.org/sru/?operation=searchRetrieve&recordSchema=isni-b&query='
 
 #See if Python 3 for unicode/str use decisions
 PY3 = version_info > (3,)


### PR DESCRIPTION
I change the base API url to the org site.
Also add an example URL call in README.md

Thanks for your code!